### PR TITLE
feat: fetch sensor from sensor_sim + send to pathfinding

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,8 +2,6 @@ from fastapi import FastAPI
 from app.routes.api_routes import router
 from app.config import CORS_SETTINGS
 from fastapi.middleware.cors import CORSMiddleware
-import sys
-import os
 import uvicorn
 
 app = FastAPI(title="Gateway")

--- a/app/main.py
+++ b/app/main.py
@@ -6,8 +6,6 @@ import sys
 import os
 import uvicorn
 
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-
 app = FastAPI(title="Gateway")
 
 # CORS

--- a/app/schemas/sensor_response_schema.py
+++ b/app/schemas/sensor_response_schema.py
@@ -1,0 +1,5 @@
+from pydantic import BaseModel
+from typing import List, Dict
+
+class sensor_data_type(BaseModel):
+    sensors: List[Dict]

--- a/app/services/pathfinding_service.py
+++ b/app/services/pathfinding_service.py
@@ -2,6 +2,8 @@ from fastapi import HTTPException
 from app.utils.forwarder import forward_request
 from app.schemas.pathfinding_schema import path_finding_request, fastest_path_type
 from app.schemas.room_response_schema import room_data_type
+from app.schemas.sensor_response_schema import sensor_data_type
+
 import os
 from dotenv import load_dotenv
 
@@ -20,16 +22,17 @@ async def calculate_fastest_path(request: path_finding_request) -> fastest_path_
         raise HTTPException(status_code=400, detail="Both 'source' and 'target' must be non-empty strings.")
     
     # Query sensor simulation service for room data.
-    sensor_sim_url = f"{SENSOR_SIM_PATH}/rooms"
+    sensor_sim_rooms_url = f"{SENSOR_SIM_PATH}/rooms"
+    sensor_sim_sensors_url = f"{SENSOR_SIM_PATH}/sensors"
 
     try:
-        room_data = await forward_request(sensor_sim_url, "GET")
+        room_data = await forward_request(sensor_sim_rooms_url, "GET")
     except Exception as e:
         raise HTTPException(
             status_code=500, 
             detail="Failed to retrieve room data from sensor simulation service"
         ) from e
-    
+
     try:
         validated_room_data = room_data_type.model_validate(room_data)
     except Exception as e:
@@ -37,21 +40,39 @@ async def calculate_fastest_path(request: path_finding_request) -> fastest_path_
             status_code=500, 
             detail="Invalid or empty room data received from sensor simulation service"
         ) from e
-
-    room_list = validated_room_data.rooms
-   
     
+    room_list = validated_room_data.rooms   
+
+    try:
+        sensor_data = await forward_request(sensor_sim_sensors_url, "GET")
+    except Exception as e:
+        raise HTTPException(
+            status_code=500, 
+            detail="Failed to retrieve sensor data from sensor simulation service"
+        ) from e
+
+    try:
+        validated_sensor_data = sensor_data_type.model_validate(sensor_data)
+    except Exception as e:
+        raise HTTPException(
+            status_code=500, 
+            detail="Invalid or empty sensor data received from sensor simulation service"
+        ) from e
+    
+    # Extract the inner list of sensors to ensure JSON serializability.
+    sensor_list = validated_sensor_data.sensors
+
     # Prepare payload for the pathfinding service.
     payload = {
         "source_sensor": request.source,
         "target_sensor": request.target,
-        "rooms": room_list
+        "rooms": room_list,
+        "sensors": sensor_list
     }
 
     # Send POST request to the pathfinding service.
     pathfinding_url = f"{PATHFINDING_PATH}/pathfinding/fastest-path"
 
-    
     try:
         path_response = await forward_request(pathfinding_url, "POST", body=payload)
     except Exception as e:
@@ -61,7 +82,7 @@ async def calculate_fastest_path(request: path_finding_request) -> fastest_path_
         ) from e
 
     try:
-        path_response = fastest_path_type.model_validate(path_response)
+        path_response = fastest_path_type.model_validate(path_response)        
     except Exception as e:
         raise HTTPException(
             status_code=500,

--- a/app/test/test_api_routes.py
+++ b/app/test/test_api_routes.py
@@ -15,9 +15,6 @@ VALID_ROOM_DATA = {"rooms": [{"id": "room1"}, {"id": "room2"}]}
 VALID_SENSOR_DATA = {"sensors": [{"id": "sensor1"}, {"id": "sensor2"}]}
 VALID_FASTEST_PATH_RESPONSE = {"fastest_path": ["RoomA", "room1", "RoomB"], "distance": 10}
 
-# Helper to run async functions.
-def run_async(coro):
-    return asyncio.run(coro)
 
 # -------------------------------
 # Tests for calculate_fastest_path

--- a/app/test/test_api_routes.py
+++ b/app/test/test_api_routes.py
@@ -5,9 +5,7 @@ import pytest
 from fastapi import HTTPException
 
 # Import the models to create valid requests/responses.
-from app.schemas.pathfinding_schema import path_finding_request, fastest_path_type
-from app.schemas.room_response_schema import room_data_type
-from app.schemas.sensor_response_schema import sensor_data_type
+from app.schemas.pathfinding_schema import path_finding_request
 
 # Import the function under test.
 from app.services import pathfinding_service


### PR DESCRIPTION
This pull request includes several changes to the `app` module to enhance the pathfinding service by integrating sensor data and improving the test suite. The most important changes include adding a new schema for sensor data, updating the pathfinding service to query and validate sensor data, and refactoring the test suite to use `pytest` and cover additional scenarios.

### Enhancements to Pathfinding Service:

* **New Sensor Data Schema**:
  - Added `sensor_data_type` schema in `app/schemas/sensor_response_schema.py` to define the structure of sensor data.

* **Integration of Sensor Data**:
  - Updated `app/services/pathfinding_service.py` to query sensor data from the sensor simulation service and include it in the payload for the pathfinding service. [[1]](diffhunk://#diff-0c9078a6d80f739c2785d0db0e8e2d9ca1cb6da6425195b30e171b737420d0faR5-R6) [[2]](diffhunk://#diff-0c9078a6d80f739c2785d0db0e8e2d9ca1cb6da6425195b30e171b737420d0faL23-R29) [[3]](diffhunk://#diff-0c9078a6d80f739c2785d0db0e8e2d9ca1cb6da6425195b30e171b737420d0faR46-L54)

### Refactoring and Improvements:

* **Test Suite Refactoring**:
  - Refactored `app/test/test_api_routes.py` to use `pytest` and added tests for various failure scenarios and successful flow in the `calculate_fastest_path` function.

* **Code Cleanup**:
  - Removed unnecessary `sys.path.append` statement from `app/main.py` to clean up the codebase.- changed main.py to not include the sys.path append that we thought we needed to make module work
- added a sensor response schema
- changed pathfinding_service.py to include sensors in the general pipeline from sensorsim to pathfinding
- changed tests accordingly, now using asyncio