### PR TITLE
feat: E2E-tests for pathfinding route

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -23,4 +23,4 @@ RUN pip install --no-cache-dir -r requirements.txt pytest pytest-cov
 COPY . /app
 
 # Run only the E2E tests
-CMD ["/wait-for-it.sh", "sensor-sim:8002", "--timeout=60", "--", "python", "-m", "pytest", "-s", "test/e2e"]
+CMD ["/wait-for-it.sh", "sensor-sim:8002", "--timeout=60", "--", "python", "-m", "pytest", "-s", "-v", "test/e2e"]

--- a/app/routes/api_routes.py
+++ b/app/routes/api_routes.py
@@ -17,31 +17,24 @@ async def get_fastest_path(request: FrontendPathFindingRequest):
 
 
 # Health check route
-@router.get('/health',
-         	tags=['Health Check'],
-				description='Check the health of the API.',
-				response_model=dict,
-    			response_description='Returns the status of the API.',
-				summary='Health check of the API.',
-    			responses={
-					200: {
-						"description": "API is healthy",
-						"content": {
-							"application/json": {
-								"example": {"status": "ok"}
-							}
-						}
-					},
-					500: {
-						"description": "Internal Server Error",
-						"content": {
-							"application/json": {
-								"example": {"status": "error"}
-							}
-						}
-					}
-				}
-			)
+@router.get(
+	'/health',
+	tags=['Health Check'],
+	description='Check the health of the API.',
+	response_model=dict,
+	response_description='Returns the status of the API.',
+	summary='Health check of the API.',
+	responses={
+		200: {
+			'description': 'API is healthy',
+			'content': {'application/json': {'example': {'status': 'ok'}}},
+		},
+		500: {
+			'description': 'Internal Server Error',
+			'content': {'application/json': {'example': {'status': 'error'}}},
+		},
+	},
+)
 async def health_check():
 	return {'status': 'ok'}
 

--- a/app/schemas/pathfinding_schema.py
+++ b/app/schemas/pathfinding_schema.py
@@ -1,10 +1,18 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator, ValidationInfo
 from typing import List
 
+
 class FrontendPathFindingRequest(BaseModel):
-    source: str
-    target: str
+	source: str
+	target: str
+
+	@field_validator('source', 'target', mode='before')
+	def check_source_and_target(cls, value, info: ValidationInfo):
+		if not value or not value.strip():
+			raise ValueError(f"Field '{info.field_name}' must be a non-empty string.")
+		return value
+
 
 class FastestPathModel(BaseModel):
-    fastest_path: List[str]
-    distance: float
+	fastest_path: List[str]
+	distance: float

--- a/app/schemas/room_response_schema.py
+++ b/app/schemas/room_response_schema.py
@@ -6,6 +6,7 @@ class RoomModel(BaseModel):
 	name: str
 	type: str
 	crowd_factor: float
+	popularity_factor: float
 	occupants: int
 	area: float
 	longitude: float

--- a/app/schemas/room_response_schema.py
+++ b/app/schemas/room_response_schema.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel
 from typing import List
 
+
 class RoomModel(BaseModel):
 	id: str
 	name: str
@@ -12,6 +13,7 @@ class RoomModel(BaseModel):
 	longitude: float
 	latitude: float
 	popularity_factor: float
+
 
 class RoomListModel(BaseModel):
 	rooms: List[RoomModel]

--- a/app/schemas/sensor_response_schema.py
+++ b/app/schemas/sensor_response_schema.py
@@ -4,6 +4,8 @@ from typing import List
 class SensorModel(BaseModel):
 	id: str
 	rooms: List[str]
+	latitude: float
+	longitude: float
 		  
 
 class SensorListModel(BaseModel):

--- a/app/services/pathfinding_service.py
+++ b/app/services/pathfinding_service.py
@@ -17,12 +17,6 @@ if PATHFINDING_PATH is None:
 
 
 async def calculate_fastest_path(request: FrontendPathFindingRequest) -> FastestPathModel:
-	# Validate input: ensure source and target are non-empty.
-	if not request.source.strip() or not request.target.strip():
-		raise HTTPException(
-			status_code=400, detail="Both 'source' and 'target' must be non-empty strings."
-		)
-
 	# Query sensor simulation service for room data.
 	sensor_sim_rooms_url = f"{SENSOR_SIM_PATH}/rooms"
 	sensor_sim_sensors_url = f"{SENSOR_SIM_PATH}/sensors"

--- a/app/services/pathfinding_service.py
+++ b/app/services/pathfinding_service.py
@@ -9,17 +9,17 @@ from dotenv import load_dotenv
 load_dotenv()
 SENSOR_SIM_PATH = os.getenv('SENSOR_SIM', 'http://localhost:8002')
 if SENSOR_SIM_PATH is None:
-	raise RuntimeError('SENSOR_SIM not found in environment variables') # pragma: no cover
+	raise RuntimeError('SENSOR_SIM not found in environment variables')  # pragma: no cover
 
 PATHFINDING_PATH = os.getenv('PATHFINDING', 'http://localhost:8001')
 if PATHFINDING_PATH is None:
-	raise RuntimeError('PATHFINDING not found in environment variables') # pragma: no cover
+	raise RuntimeError('PATHFINDING not found in environment variables')  # pragma: no cover
 
 
 async def calculate_fastest_path(request: FrontendPathFindingRequest) -> FastestPathModel:
 	# Query sensor simulation service for room data.
-	sensor_sim_rooms_url = f"{SENSOR_SIM_PATH}/rooms"
-	sensor_sim_sensors_url = f"{SENSOR_SIM_PATH}/sensors"
+	sensor_sim_rooms_url = f'{SENSOR_SIM_PATH}/rooms'
+	sensor_sim_sensors_url = f'{SENSOR_SIM_PATH}/sensors'
 
 	try:
 		room_data, _ = await forward_request(sensor_sim_rooms_url, 'GET')
@@ -35,7 +35,7 @@ async def calculate_fastest_path(request: FrontendPathFindingRequest) -> Fastest
 			status_code=500,
 			detail='Invalid or empty room data received from sensor simulation service',
 		) from e
-	
+
 	try:
 		sensor_data, _ = await forward_request(sensor_sim_sensors_url, 'GET')
 	except Exception as e:
@@ -50,25 +50,29 @@ async def calculate_fastest_path(request: FrontendPathFindingRequest) -> Fastest
 			status_code=500,
 			detail='Invalid or empty sensor data received from sensor simulation service',
 		) from e
-	
+
 	# Prepare payload for the pathfinding service.
-	payload = {'source_sensor': request.source, 'target_sensor': request.target, 'rooms': room_data['rooms'], 'sensors': sensor_data['sensors']}
+	payload = {
+		'source_sensor': request.source,
+		'target_sensor': request.target,
+		'rooms': room_data['rooms'],
+		'sensors': sensor_data['sensors'],
+	}
 
 	# Send POST request to the pathfinding service.
 	pathfinding_url = f'{PATHFINDING_PATH}/pathfinding/fastest-path'
 
 	try:
 		path_response, status = await forward_request(pathfinding_url, 'POST', body=payload)
-	except Exception as e:
-		raise HTTPException(
+	except Exception as e:  # pragma: no cover
+		raise HTTPException(  # pragma: no cover
 			status_code=500, detail='Error communicating with pathfinding service'
 		) from e
 
 	try:
 		path_response = FastestPathModel.model_validate(path_response)
-	except Exception as e:
-		print(e)
-		raise HTTPException(
+	except Exception as e:  # pragma: no cover)
+		raise HTTPException(  # pragma: no cover
 			status_code=status, detail=path_response.get('detail', 'Invalid pathfinding response')
 		) from e
 

--- a/app/services/rooms_controllers.py
+++ b/app/services/rooms_controllers.py
@@ -7,11 +7,11 @@ from fastapi import HTTPException
 load_dotenv()
 SENSOR_SIM_PATH = os.getenv('SENSOR_SIM', 'http://localhost:8002')
 if SENSOR_SIM_PATH is None:
-	raise RuntimeError('SENSOR_SIM not found in environment variables') # pragma: no cover
+	raise RuntimeError('SENSOR_SIM not found in environment variables')  # pragma: no cover
 
 PATHFINDING_PATH = os.getenv('PATHFINDING', 'http://localhost:8001')
 if PATHFINDING_PATH is None:
-	raise RuntimeError('PATHFINDING not found in environment variables') # pragma: no cover
+	raise RuntimeError('PATHFINDING not found in environment variables')  # pragma: no cover
 
 
 async def get_all_rooms() -> RoomListModel:

--- a/app/services/sensor_controllers.py
+++ b/app/services/sensor_controllers.py
@@ -7,31 +7,33 @@ from fastapi import HTTPException
 load_dotenv()
 SENSOR_SIM_PATH = os.getenv('SENSOR_SIM', 'http://localhost:8002')
 if SENSOR_SIM_PATH is None:
-	raise RuntimeError('SENSOR_SIM not found in environment variables') # pragma: no cover
+	raise RuntimeError('SENSOR_SIM not found in environment variables')  # pragma: no cover
 
 PATHFINDING_PATH = os.getenv('PATHFINDING', 'http://localhost:8001')
 if PATHFINDING_PATH is None:
-	raise RuntimeError('PATHFINDING not found in environment variables') # pragma: no cover
+	raise RuntimeError('PATHFINDING not found in environment variables')  # pragma: no cover
+
 
 async def get_all_sensors() -> SensorListModel:
 	res, status = await forward_request(SENSOR_SIM_PATH + '/sensors', 'GET')
-	try: 
+	try:
 		SensorListModel.model_validate(res, strict=True)
 		return res
 	except Exception:
 		raise HTTPException(
 			status_code=status,
-			detail=res.get('detail', 'Invalid room data received from sensor simulation service')
+			detail=res.get('detail', 'Invalid room data received from sensor simulation service'),
 		)
-  
+
+
 async def get_sensor_by_id(sensor_id: str) -> SensorModel:
 	res, status = await forward_request(SENSOR_SIM_PATH + f'/sensors/{sensor_id}', 'GET')
-  
-	try: 
+
+	try:
 		SensorModel.model_validate(res, strict=True)
 		return res
 	except Exception:
 		raise HTTPException(
 			status_code=status,
-			detail=res.get('detail', 'Invalid room data received from sensor simulation service')
+			detail=res.get('detail', 'Invalid room data received from sensor simulation service'),
 		)

--- a/app/services/smk_api.py
+++ b/app/services/smk_api.py
@@ -2,64 +2,71 @@ import httpx
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
-router = APIRouter(prefix="/smk")
+router = APIRouter(prefix='/smk')
+
 
 class SMKRequest(BaseModel):
-    content: str
+	content: str
+
 
 async def search_artwork(keys: str):
-    """
-    Calls the external SMK API to search for artworks.
-    
-    
-    Parameters:
-        - `keys`: Search term (e.g., "minimumsbetragtning")
-    """
-    if not keys.strip():
-        raise HTTPException(status_code=400, detail="The 'keys' parameter must be a non-empty string.")
-    
-    params = {
-        "keys": keys,
-    }
+	"""
+	Calls the external SMK API to search for artworks.
 
-    try:
-        async with httpx.AsyncClient() as client:
-            response = await client.get("https://api.smk.dk/api/v1/art/search", params=params)
-            response.raise_for_status()
-            data = response.json()
-            filtered_data = data.get("autocomplete")
-            return filtered_data
 
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Internal server error: {str(e)}")
+	Parameters:
+	    - `keys`: Search term (e.g., "minimumsbetragtning")
+	"""
+	if not keys.strip():
+		raise HTTPException(
+			status_code=400, detail="The 'keys' parameter must be a non-empty string."
+		)
+
+	params = {
+		'keys': keys,
+	}
+
+	try:
+		async with httpx.AsyncClient() as client:
+			response = await client.get('https://api.smk.dk/api/v1/art/search', params=params)
+			response.raise_for_status()
+			data = response.json()
+			filtered_data = data.get('autocomplete')
+			return filtered_data
+
+	except Exception as e:
+		raise HTTPException(status_code=500, detail=f'Internal server error: {str(e)}')
+
 
 async def get_artwork(keys: str):
-    """
-    Calls the external SMK API to get an artwork.
-    
-    
-    Parameters:
-        - `keys`: Search term (e.g., "minimumsbetragtning")
-    """
-    if not keys.strip():
-        raise HTTPException(status_code=400, detail="The 'keys' parameter must be a non-empty string.")
-    
-    params = {
-        "keys": keys,
-    }
+	"""
+	Calls the external SMK API to get an artwork.
 
-    try:
-        async with httpx.AsyncClient() as client:
-            response = await client.get("https://api.smk.dk/api/v1/art/search", params=params)
-            response.raise_for_status()
-            data = response.json()
-            filtered_data = [
-                {
-                    "id": data.get("items", [{}])[0].get("id"),
-                    "room": data.get("items", [{}])[0].get("current_location_name"),
-                }
-            ]
-            return filtered_data
 
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Internal server error: {str(e)}")
+	Parameters:
+	    - `keys`: Search term (e.g., "minimumsbetragtning")
+	"""
+	if not keys.strip():
+		raise HTTPException(
+			status_code=400, detail="The 'keys' parameter must be a non-empty string."
+		)
+
+	params = {
+		'keys': keys,
+	}
+
+	try:
+		async with httpx.AsyncClient() as client:
+			response = await client.get('https://api.smk.dk/api/v1/art/search', params=params)
+			response.raise_for_status()
+			data = response.json()
+			filtered_data = [
+				{
+					'id': data.get('items', [{}])[0].get('id'),
+					'room': data.get('items', [{}])[0].get('current_location_name'),
+				}
+			]
+			return filtered_data
+
+	except Exception as e:
+		raise HTTPException(status_code=500, detail=f'Internal server error: {str(e)}')

--- a/app/test/e2e/pathfinding/test_pathfinding.py
+++ b/app/test/e2e/pathfinding/test_pathfinding.py
@@ -38,9 +38,9 @@ def test_pathfinding(sensor_ids):
 	assert 'fastest_path' in data
 	assert isinstance(data['fastest_path'], list)
 	assert len(data['fastest_path']) > 0
-	for room in data['fastest_path']:
-		assert isinstance(room, str)
-		assert room.isalnum()
+	for sensor in data['fastest_path']:
+		assert isinstance(sensor, str)
+		assert sensor.isalnum()
 	assert 'distance' in data
 	assert isinstance(data['distance'], (int, float))
  

--- a/app/test/e2e/pathfinding/test_pathfinding.py
+++ b/app/test/e2e/pathfinding/test_pathfinding.py
@@ -1,0 +1,124 @@
+import pytest
+import requests
+
+@pytest.fixture(scope='module')
+def sensor_ids():
+	"""Fixture to get a room ID from /sensors endpoint."""
+	BASE_URL = 'http://gateway:8000'
+
+	response = requests.get(BASE_URL + '/sensors')
+	assert response.status_code == 200
+	data = response.json()
+	assert isinstance(data, dict)
+	assert 'sensors' in data
+	assert len(data['sensors']) > 0
+	sensor_id1 = data['sensors'][0]['id']
+	sensor_id2 = data['sensors'][20]['id']
+	return sensor_id1, sensor_id2
+
+def test_pathfinding(sensor_ids):
+	"""Test the /fastest-path endpoint."""
+
+	BASE_URL = 'http://gateway:8000'
+ 
+	sensor_id1, sensor_id2 = sensor_ids
+
+	# Define the request body
+	request_body = {
+		"source": sensor_id1,
+		"target": sensor_id2,
+	}
+
+	response = requests.post(BASE_URL + '/fastest-path', json=request_body)
+ 
+	print(response.json())
+	assert response.status_code == 200
+	data = response.json()
+	assert isinstance(data, dict)
+	assert 'fastest_path' in data
+	assert isinstance(data['fastest_path'], list)
+	assert len(data['fastest_path']) > 0
+	for room in data['fastest_path']:
+		assert isinstance(room, str)
+		assert room.isalnum()
+	assert 'distance' in data
+	assert isinstance(data['distance'], (int, float))
+ 
+ 
+def test_pathfinding_invalid_source(sensor_ids):
+	"""Test the /fastest-path endpoint with invalid source."""
+	BASE_URL = 'http://gateway:8000'
+	sensor_id1, sensor_id2 = sensor_ids
+	# Define the request body
+	request_body = {
+		"source": "invalid_source",
+		"target": sensor_id2,
+	}
+	response = requests.post(BASE_URL + '/fastest-path', json=request_body)
+	assert response.status_code == 400
+	data = response.json()
+	assert isinstance(data, dict)
+	assert 'detail' in data
+	assert data['detail'] == "Source sensor 'invalid_source' not found in the sensor graph."
+ 
+def test_pathfinding_invalid_target(sensor_ids):
+	"""Test the /fastest-path endpoint with invalid target."""
+	BASE_URL = 'http://gateway:8000'
+	sensor_id1, sensor_id2 = sensor_ids
+	# Define the request body
+	request_body = {
+		"source": sensor_id1,
+		"target": "invalid_target",
+	}
+	response = requests.post(BASE_URL + '/fastest-path', json=request_body)
+	assert response.status_code == 400
+	data = response.json()
+	assert isinstance(data, dict)
+	assert 'detail' in data
+	assert data['detail'] == "Target sensor 'invalid_target' not found in the sensor graph."
+ 
+def test_pathfinding_empty_source(sensor_ids):
+	"""Test the /fastest-path endpoint with empty source."""
+	BASE_URL = 'http://gateway:8000'
+	sensor_id1, sensor_id2 = sensor_ids
+	# Define the request body
+	request_body = {
+		"source": "",
+		"target": sensor_id2,
+	}
+	response = requests.post(BASE_URL + '/fastest-path', json=request_body)
+	assert response.status_code == 422
+	data = response.json()
+	assert isinstance(data, dict)
+	assert 'detail' in data
+	assert data['detail'] == [{
+		'ctx': {
+			'error': {}
+		},
+		'input': '',
+		'type': 'value_error',
+		'loc': ['body', 'source'],
+		'msg': "Value error, Field 'source' must be a non-empty string."
+	}]
+ 
+def test_pathfinding_no_target(sensor_ids):
+	"""Test the /fastest-path endpoint with no target."""
+	BASE_URL = 'http://gateway:8000'
+	sensor_id1, sensor_id2 = sensor_ids
+	# Define the request body
+	request_body = {
+		"source": sensor_id1,
+	}
+	response = requests.post(BASE_URL + '/fastest-path', json=request_body)
+	assert response.status_code == 422
+	data = response.json()
+	assert isinstance(data, dict)
+	assert 'detail' in data
+	assert data['detail'] == [{
+		'input': {
+			'source': sensor_id1
+   	},
+		'type': 'missing',
+		'loc': ['body', 'target'],
+		'msg': "Field required"
+	}]

--- a/app/test/routes/test_api_routes.py
+++ b/app/test/routes/test_api_routes.py
@@ -12,12 +12,17 @@ app = FastAPI()
 app.include_router(router)
 client = TestClient(app)
 
+
 @pytest.fixture(autouse=True)
 def mock_env(monkeypatch):
-    monkeypatch.setattr("app.services.pathfinding_service.os.getenv", lambda key, default=None: {
-        "SENSOR_SIM": "http://mock-sensor-sim",
-        "PATHFINDING": "http://mock-pathfinding"
-    }.get(key, default))
+	monkeypatch.setattr(
+		'app.services.pathfinding_service.os.getenv',
+		lambda key, default=None: {
+			'SENSOR_SIM': 'http://mock-sensor-sim',
+			'PATHFINDING': 'http://mock-pathfinding',
+		}.get(key, default),
+	)
+
 
 @pytest.fixture()
 def valid_room_data():
@@ -32,7 +37,7 @@ def valid_room_data():
 				'area': 100.0,
 				'longitude': 1.0,
 				'latitude': 1.0,
-				'popularity_factor': 1.0
+				'popularity_factor': 1.0,
 			},
 			{
 				'id': 'room2',
@@ -43,42 +48,47 @@ def valid_room_data():
 				'area': 100.0,
 				'longitude': 1.0,
 				'latitude': 1.0,
-				'popularity_factor': 1.0
+				'popularity_factor': 1.0,
 			},
 		]
 	}
 
+
 @pytest.fixture
 def valid_sensor_data():
-    return {
-        "sensors": [
-            {"id": "sensor1", "rooms": ["RoomA", "RoomB"]},
-            {"id": "sensor2", "rooms": ["RoomA", "RoomB"]}
-        ]
-    }
+	return {
+		'sensors': [
+			{'id': 'sensor1', 'rooms': ['RoomA', 'RoomB'], 'latitude': 1.0, 'longitude': 1.0},
+			{'id': 'sensor2', 'rooms': ['RoomA', 'RoomB'], 'latitude': 1.0, 'longitude': 1.0},
+		]
+	}
+
+
 @pytest.fixture
 def valid_fastest_path_response():
-	return {"fastest_path": ["RoomA", "room1", "RoomB"], "distance": 10}
+	return {'fastest_path': ['RoomA', 'room1', 'RoomB'], 'distance': 10}
+
 
 def test_health_check():
 	response = client.get('/health')
 	assert response.status_code == 200
 	assert response.json() == {'status': 'ok'}
 
+
 # Test: Blank source value should trigger 400 error.
 def test_blank_source():
 	payload = {'source': '   ', 'target': 'RoomA'}
 	response = client.post('/fastest-path', json=payload)
 	assert response.status_code == 422
-	assert response.json()['detail'] == [{
-		'ctx': {
-			'error': {}
-		},
-		'input': '   ',
-		'type': 'value_error',
-		'loc': ['body', 'source'],
-		'msg': "Value error, Field 'source' must be a non-empty string."
-	}]
+	assert response.json()['detail'] == [
+		{
+			'ctx': {'error': {}},
+			'input': '   ',
+			'type': 'value_error',
+			'loc': ['body', 'source'],
+			'msg': "Value error, Field 'source' must be a non-empty string.",
+		}
+	]
 
 
 # Test: Blank target value should trigger 400 error.
@@ -86,15 +96,15 @@ def test_blank_target():
 	payload = {'source': 'RoomA', 'target': '   '}
 	response = client.post('/fastest-path', json=payload)
 	assert response.status_code == 422
-	assert response.json()['detail'] == [{
-		'ctx': {
-			'error': {}
-		},
-		'input': '   ',
-		'type': 'value_error',
-		'loc': ['body', 'target'],
-		'msg': "Value error, Field 'target' must be a non-empty string."
-	}]
+	assert response.json()['detail'] == [
+		{
+			'ctx': {'error': {}},
+			'input': '   ',
+			'type': 'value_error',
+			'loc': ['body', 'target'],
+			'msg': "Value error, Field 'target' must be a non-empty string.",
+		}
+	]
 
 
 # Test: Simulate sensor simulation service failure (first forward_request call fails).
@@ -141,7 +151,9 @@ def test_pathfinding_failure(monkeypatch, valid_room_data):
 	payload = {'source': 'RoomA', 'target': 'RoomB'}
 	response = client.post('/fastest-path', json=payload)
 	assert response.status_code == 500
-	assert 'Failed to retrieve sensor data from sensor simulation service' in response.json()['detail']
+	assert (
+		'Failed to retrieve sensor data from sensor simulation service' in response.json()['detail']
+	)
 
 
 # Test: When pathfinding returns an invalid response (not a dict).
@@ -163,7 +175,10 @@ def test_invalid_pathfinding_response(monkeypatch, valid_room_data):
 	payload = {'source': 'RoomA', 'target': 'RoomB'}
 	response = client.post('/fastest-path', json=payload)
 	assert response.status_code == 500
-	assert 'Invalid or empty sensor data received from sensor simulation service' in response.json()['detail']
+	assert (
+		'Invalid or empty sensor data received from sensor simulation service'
+		in response.json()['detail']
+	)
 
 
 # Test: A successful flow where both forward_request calls return valid data.
@@ -177,14 +192,14 @@ def test_success(monkeypatch, valid_room_data, valid_sensor_data, valid_fastest_
 			# Return room data as a dictionary with a "rooms" key.
 			return valid_room_data, 200
 		elif call_count == 2:
-			# return sensor data 
+			# return sensor data
 			return valid_sensor_data, 200
 		elif call_count == 3:
 			# Return a valid pathfinding response with the expected keys.
 			return valid_fastest_path_response, 200
 		else:
-			raise Exception(f"Unexpected API call with count {call_count}")
-		
+			raise Exception(f'Unexpected API call with count {call_count}')
+
 	monkeypatch.setattr('app.services.pathfinding_service.forward_request', fake_forward_request)
 
 	payload = {'source': 'RoomA', 'target': 'RoomB'}
@@ -195,12 +210,20 @@ def test_success(monkeypatch, valid_room_data, valid_sensor_data, valid_fastest_
 	assert 'fastest_path' in json_response
 	assert 'distance' in json_response
 
+
 def test_missing_pathfinding(monkeypatch):
-    monkeypatch.setattr("app.services.pathfinding_service.os.getenv", lambda key, default=None: None if key == "PATHFINDING" else default)
-    with pytest.raises(RuntimeError, match="PATHFINDING not found"):
-        importlib.reload(pathfinding_service)
+	monkeypatch.setattr(
+		'app.services.pathfinding_service.os.getenv',
+		lambda key, default=None: None if key == 'PATHFINDING' else default,
+	)
+	with pytest.raises(RuntimeError, match='PATHFINDING not found'):
+		importlib.reload(pathfinding_service)
+
 
 def test_missing_sensor_sim(monkeypatch):
-    monkeypatch.setattr("app.services.pathfinding_service.os.getenv", lambda key, default=None: None if key == "SENSOR_SIM" else default)
-    with pytest.raises(RuntimeError, match="SENSOR_SIM not found"):
-        importlib.reload(pathfinding_service)
+	monkeypatch.setattr(
+		'app.services.pathfinding_service.os.getenv',
+		lambda key, default=None: None if key == 'SENSOR_SIM' else default,
+	)
+	with pytest.raises(RuntimeError, match='SENSOR_SIM not found'):
+		importlib.reload(pathfinding_service)

--- a/app/test/routes/test_api_routes.py
+++ b/app/test/routes/test_api_routes.py
@@ -69,16 +69,32 @@ def test_health_check():
 def test_blank_source():
 	payload = {'source': '   ', 'target': 'RoomA'}
 	response = client.post('/fastest-path', json=payload)
-	assert response.status_code == 400
-	assert 'non-empty' in response.json()['detail']
+	assert response.status_code == 422
+	assert response.json()['detail'] == [{
+		'ctx': {
+			'error': {}
+		},
+		'input': '   ',
+		'type': 'value_error',
+		'loc': ['body', 'source'],
+		'msg': "Value error, Field 'source' must be a non-empty string."
+	}]
 
 
 # Test: Blank target value should trigger 400 error.
 def test_blank_target():
 	payload = {'source': 'RoomA', 'target': '   '}
 	response = client.post('/fastest-path', json=payload)
-	assert response.status_code == 400
-	assert 'non-empty' in response.json()['detail']
+	assert response.status_code == 422
+	assert response.json()['detail'] == [{
+		'ctx': {
+			'error': {}
+		},
+		'input': '   ',
+		'type': 'value_error',
+		'loc': ['body', 'target'],
+		'msg': "Value error, Field 'target' must be a non-empty string."
+	}]
 
 
 # Test: Simulate sensor simulation service failure (first forward_request call fails).

--- a/app/test/routes/test_room_routes.py
+++ b/app/test/routes/test_room_routes.py
@@ -8,6 +8,7 @@ from fastapi import HTTPException
 def mock_get_all_rooms(mocker):
 	return mocker.patch('app.routes.room_routes.get_all_rooms')
 
+
 @pytest.fixture
 def mock_get_room_by_id(mocker):
 	return mocker.patch('app.routes.room_routes.get_room_by_id')
@@ -24,7 +25,7 @@ def mock_room():
 		'area': 100.0,
 		'longitude': 1.0,
 		'latitude': 1.0,
-		'popularity_factor': 1.0
+		'popularity_factor': 1.0,
 	}
 
 
@@ -39,7 +40,7 @@ async def test_get_all_rooms_route(client, mock_get_all_rooms, mock_room):
 	mock_response = {'rooms': [mock_room, mock_room]}
 	mock_get_all_rooms.return_value = mock_response
 
-	response = client.get('/rooms/') 
+	response = client.get('/rooms/')
 
 	assert response.status_code == 200
 	assert response.json() == mock_response
@@ -68,4 +69,6 @@ async def test_get_room_by_id_invalid_response(client, mock_get_room_by_id):
 	with pytest.raises(HTTPException) as exc:
 		client.get(f'/rooms/{room_id}')
 		assert exc.value.status_code == 404, f'Expected 404, got {exc.value.status_code}'
-		assert exc.value.detail == 'Room not found', f'Expected "Room not found", got {exc.value.detail}'
+		assert exc.value.detail == 'Room not found', (
+			f'Expected "Room not found", got {exc.value.detail}'
+		)

--- a/app/test/routes/test_sensor_routes.py
+++ b/app/test/routes/test_sensor_routes.py
@@ -6,60 +6,66 @@ from fastapi import HTTPException
 
 @pytest.fixture
 def mock_get_all_sensors(mocker):
-    return mocker.patch('app.routes.sensor_routes.get_all_sensors')
+	return mocker.patch('app.routes.sensor_routes.get_all_sensors')
 
 
 @pytest.fixture
 def mock_get_sensor_by_id(mocker):
-    return mocker.patch('app.routes.sensor_routes.get_sensor_by_id')
+	return mocker.patch('app.routes.sensor_routes.get_sensor_by_id')
 
 
 @pytest.fixture
 def mock_sensor():
-    return {
-        'id': '67e52c913161b5df7189df14',
-        'rooms': ['room_1', 'room_2'],
-    }
+	return {
+		'id': '67e52c913161b5df7189df14',
+		'rooms': ['room_1', 'room_2'],
+		'latitude': 1.0,
+		'longitude': 1.0,
+	}
 
 
 @pytest.fixture
 def client():
-    with TestClient(router) as client:
-        yield client
+	with TestClient(router) as client:
+		yield client
 
 
 @pytest.mark.asyncio
 async def test_get_all_sensors_route(client, mock_get_all_sensors, mock_sensor):
-    mock_response = {'sensors': [mock_sensor, mock_sensor]}
-    mock_get_all_sensors.return_value = mock_response
+	mock_response = {'sensors': [mock_sensor, mock_sensor]}
+	mock_get_all_sensors.return_value = mock_response
 
-    response = client.get('/sensors/')  # Assuming the endpoint is '/sensors/'
+	response = client.get('/sensors/')  # Assuming the endpoint is '/sensors/'
 
-    assert response.status_code == 200
-    assert response.json() == mock_response
-    mock_get_all_sensors.assert_called_once()
+	assert response.status_code == 200
+	assert response.json() == mock_response
+	mock_get_all_sensors.assert_called_once()
 
 
 @pytest.mark.asyncio
 async def test_get_sensor_by_id_route(client, mock_get_sensor_by_id, mock_sensor):
-    sensor_id = '67e52c913161b5df7189df14'
-    # Mocking the response for 'get_sensor_by_id'
-    mock_response = mock_sensor
-    mock_get_sensor_by_id.return_value = mock_response
+	sensor_id = '67e52c913161b5df7189df14'
+	# Mocking the response for 'get_sensor_by_id'
+	mock_response = mock_sensor
+	mock_get_sensor_by_id.return_value = mock_response
 
-    response = client.get(f'/sensors/{sensor_id}')  # Assuming the endpoint is '/sensors/{sensor_id}'
+	response = client.get(
+		f'/sensors/{sensor_id}'
+	)  # Assuming the endpoint is '/sensors/{sensor_id}'
 
-    assert response.status_code == 200
-    assert response.json() == mock_response
-    mock_get_sensor_by_id.assert_called_once_with(sensor_id)
+	assert response.status_code == 200
+	assert response.json() == mock_response
+	mock_get_sensor_by_id.assert_called_once_with(sensor_id)
 
 
 @pytest.mark.asyncio
 async def test_get_sensor_by_id_invalid_response(client, mock_get_sensor_by_id):
-    sensor_id = 'non_existent_id'
-    mock_get_sensor_by_id.side_effect = HTTPException(detail='Sensor not found', status_code=404)
+	sensor_id = 'non_existent_id'
+	mock_get_sensor_by_id.side_effect = HTTPException(detail='Sensor not found', status_code=404)
 
-    with pytest.raises(HTTPException) as exc:
-        client.get(f'/sensors/{sensor_id}')
-    assert exc.value.status_code == 404, f'Expected 404, got {exc.value.status_code}'
-    assert exc.value.detail == 'Sensor not found', f'Expected "Sensor not found", got {exc.value.detail}'
+	with pytest.raises(HTTPException) as exc:
+		client.get(f'/sensors/{sensor_id}')
+	assert exc.value.status_code == 404, f'Expected 404, got {exc.value.status_code}'
+	assert exc.value.detail == 'Sensor not found', (
+		f'Expected "Sensor not found", got {exc.value.detail}'
+	)

--- a/app/test/services/test_rooms_controllers.py
+++ b/app/test/services/test_rooms_controllers.py
@@ -28,12 +28,12 @@ def mock_room():
 		'area': 100.0,
 		'longitude': 1.0,
 		'latitude': 1.0,
-		'popularity_factor': 1.0
+		'popularity_factor': 1.0,
 	}
 
 
 @pytest.mark.asyncio
-async def test_get_all_rooms(mock_env, mock_forward_request, mock_room):  
+async def test_get_all_rooms(mock_env, mock_forward_request, mock_room):
 	mock_response = {'rooms': [mock_room, mock_room]}
 	mock_forward_request.return_value = (mock_response, 200)
 
@@ -67,11 +67,10 @@ async def test_get_room_by_id(mock_env, mock_forward_request, mock_room):
 
 @pytest.mark.asyncio
 async def test_get_room_by_id_invalid_response(mock_env, mock_forward_request):
-	mock_forward_request.return_value = ({ 'details': 'This is an error' }, 500)
+	mock_forward_request.return_value = ({'details': 'This is an error'}, 500)
 
 	with pytest.raises(HTTPException) as exc:
 		await get_room_by_id('1')
 
 	assert exc.value.status_code == 500
 	assert exc.value.detail == 'Invalid room data received from sensor simulation service'
- 

--- a/app/test/services/test_sensor_controllers.py
+++ b/app/test/services/test_sensor_controllers.py
@@ -3,65 +3,78 @@ from fastapi import HTTPException
 from app.services.sensor_controllers import get_all_sensors, get_sensor_by_id
 from app.schemas.sensor_response_schema import SensorModel, SensorListModel
 
+
 # Mocking the environment variables
 @pytest.fixture
 def mock_env(monkeypatch):
-    monkeypatch.setattr('app.services.sensor_controllers.SENSOR_SIM_PATH', 'http://mock-sensor-sim')
-    monkeypatch.setattr('app.services.sensor_controllers.PATHFINDING_PATH', 'http://mock-pathfinding')
+	monkeypatch.setattr('app.services.sensor_controllers.SENSOR_SIM_PATH', 'http://mock-sensor-sim')
+	monkeypatch.setattr(
+		'app.services.sensor_controllers.PATHFINDING_PATH', 'http://mock-pathfinding'
+	)
+
 
 # Mocking the forward_request method
 @pytest.fixture
 def mock_forward_request(mocker):
-    return mocker.patch('app.services.sensor_controllers.forward_request')
+	return mocker.patch('app.services.sensor_controllers.forward_request')
+
 
 # Mocking a sample sensor
 @pytest.fixture
 def mock_sensor():
-    return {
-        "id": "sensor_123",
-        "rooms": ["room_1", "room_2"],
-    }
+	return {
+		'id': 'sensor_123',
+		'rooms': ['room_1', 'room_2'],
+		'latitude': 1.0,
+		'longitude': 1.0,
+	}
+
 
 # Test for getting all sensors
 @pytest.mark.asyncio
 async def test_get_all_sensors(mock_env, mock_forward_request, mock_sensor):
-    mock_response = {'sensors': [mock_sensor, mock_sensor]}
-    mock_forward_request.return_value = (mock_response, 200)
+	mock_response = {'sensors': [mock_sensor, mock_sensor]}
+	mock_forward_request.return_value = (mock_response, 200)
 
-    result = await get_all_sensors()
+	result = await get_all_sensors()
 
-    assert SensorListModel.model_validate(result) == SensorListModel.model_validate(mock_response)
-    mock_forward_request.assert_called_once_with('http://mock-sensor-sim/sensors', 'GET')
+	assert SensorListModel.model_validate(result) == SensorListModel.model_validate(mock_response)
+	mock_forward_request.assert_called_once_with('http://mock-sensor-sim/sensors', 'GET')
+
 
 # Test for handling invalid response when getting all sensors
 @pytest.mark.asyncio
 async def test_get_all_sensors_invalid_response(mock_env, mock_forward_request):
-    mock_forward_request.return_value = ({'details': 'Invalid response'}, 500)
+	mock_forward_request.return_value = ({'details': 'Invalid response'}, 500)
 
-    with pytest.raises(HTTPException) as exc:
-        await get_all_sensors()
+	with pytest.raises(HTTPException) as exc:
+		await get_all_sensors()
 
-    assert exc.value.status_code == 500
-    assert exc.value.detail == 'Invalid room data received from sensor simulation service'
+	assert exc.value.status_code == 500
+	assert exc.value.detail == 'Invalid room data received from sensor simulation service'
+
 
 # Test for getting a sensor by ID
 @pytest.mark.asyncio
 async def test_get_sensor_by_id(mock_env, mock_forward_request, mock_sensor):
-    sensor_id = "sensor_123"
-    mock_forward_request.return_value = (mock_sensor, 200)
+	sensor_id = 'sensor_123'
+	mock_forward_request.return_value = (mock_sensor, 200)
 
-    result = await get_sensor_by_id(sensor_id)
+	result = await get_sensor_by_id(sensor_id)
 
-    assert SensorModel.model_validate(result) == SensorModel.model_validate(mock_sensor)
-    mock_forward_request.assert_called_once_with(f'http://mock-sensor-sim/sensors/{sensor_id}', 'GET')
+	assert SensorModel.model_validate(result) == SensorModel.model_validate(mock_sensor)
+	mock_forward_request.assert_called_once_with(
+		f'http://mock-sensor-sim/sensors/{sensor_id}', 'GET'
+	)
+
 
 # Test for handling invalid response when getting a sensor by ID
 @pytest.mark.asyncio
 async def test_get_sensor_by_id_invalid_response(mock_env, mock_forward_request):
-    mock_forward_request.return_value = ({'details': 'This is an error'}, 404)
+	mock_forward_request.return_value = ({'details': 'This is an error'}, 404)
 
-    with pytest.raises(HTTPException) as exc:
-        await get_sensor_by_id('sensor_123')
+	with pytest.raises(HTTPException) as exc:
+		await get_sensor_by_id('sensor_123')
 
-    assert exc.value.status_code == 404
-    assert exc.value.detail == 'Invalid room data received from sensor simulation service'
+	assert exc.value.status_code == 404
+	assert exc.value.detail == 'Invalid room data received from sensor simulation service'

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -95,7 +95,7 @@ services:
       - gateway   
       - sensor-sim
       - pathfinding
-    command: ["/wait-for-it.sh", "sensor-sim:8002", "--timeout=60", "--", "python", "-m", "pytest", "-s", "app/test/e2e"]
+    command: ["/wait-for-it.sh", "sensor-sim:8002", "--timeout=60", "--", "python", "-m", "pytest", "-s", "-vv", "app/test/e2e"]
 
 volumes:
   zookeeper_data:


### PR DESCRIPTION
This pull request includes several changes to improve the codebase and add new functionality. The most important changes include adding new validation for the `FrontendPathFindingRequest` schema, adding a new field to the `RoomModel` schema, and enhancing the end-to-end tests for the pathfinding feature.

Schema improvements:

* [`app/schemas/pathfinding_schema.py`](diffhunk://#diff-a3992bdda0ad08b7cd5c5080a3e125a7f5ee5742a1f876cd3d173ca99145ad66L1-R15): Added a `field_validator` to ensure that the `source` and `target` fields are non-empty strings.
* [`app/schemas/room_response_schema.py`](diffhunk://#diff-8a7d2d3a77feafb39583cb1851c5636255b033e8888257b42b3d83bccaafb814R9): Added a new `popularity_factor` field to the `RoomModel` schema.

Testing enhancements:

* [`app/test/e2e/pathfinding/test_pathfinding.py`](diffhunk://#diff-d85da95cf1d2bf708a995b69920e533b5776545164f2c0f791e88bea0e769e9fL20-R36): Added new end-to-end tests for the `/fastest-path` endpoint, including tests for invalid and empty inputs.

Configuration updates:

* [`Dockerfile.test`](diffhunk://#diff-5faf10fde2b24acdf4f05e70be1be9d50921d685e64f781d242e056b11d79dccL26-R26): Updated the `CMD` to include the `-v` flag for more verbose test output.
* [`docker-compose.e2e.yml`](diffhunk://#diff-29d8d8c569345f7e4339e3bab5342fa39d73d2293303d372c0f00cd04ad242ebL98-R98): Updated the `command` to include the `-vv` flag for more verbose test output.