### PR TITLE
fix: small fixes to search for easier use

### DIFF
--- a/app/schemas/smk_api_schemas.py
+++ b/app/schemas/smk_api_schemas.py
@@ -82,7 +82,15 @@ class ArtworkResponse(BaseModel):
 	items: List[Artwork]
 	facets: Optional[Dict[str, Any]] = {}
 	facets_ranges: Optional[Dict[str, Any]] = {}
-	autocomplete: Optional[List[str]] = []
+ 
+	def __init__(self, **data):
+		super().__init__(**data)
+		self.offset = data.get('offset', 0)
+		self.rows = data.get('rows', 0)
+		self.found = data.get('found', 0)
+		self.items = [Artwork(**item) for item in data.get('items', [])]
+		self.facets = data.get('facets', {})
+		self.facets_ranges = data.get('facets_ranges', {})
 
 
 artwork_response_example: Dict[int | str, Dict[str, Any]] = {

--- a/app/services/smk_api.py
+++ b/app/services/smk_api.py
@@ -29,6 +29,7 @@ async def search_artwork(keys: str):
 
 	params = {
 		'keys': keys,
+		'filters': '[on_display:true]',
 	}
 
 	try:
@@ -56,18 +57,26 @@ async def query_artwork(query_obj: FilterParams=Depends()) -> ArtworkResponse:
 			raise HTTPException(status_code=status, detail=room['detail'])
 
  
-	fields = 'current_location_name,dimensions,artist,acquisition_date,responsible_department,titles,production_date,colors,techniques'
- 
 	artworks, _ = await forward_request(
 		'https://api.smk.dk/api/v1/art/search',
 		'GET',
 		params={
 			'keys': query.get('keys') if query.get('keys') else '*',
-			'filters': f'[current_location_name:{room.get("name", "")}]' if room else None,
+			'filters': f'[current_location_name:{room.get("name", "")}]' if room else "[on_display:true]",
 			'rows': min(query.get('limit', math.inf), 2000) if query.get('limit') else None,
 			'offset': query.get('offset', None) if query.get('offset') else None,
-			'fields': fields,
+			'qfields': 'titles,creator,tags',
 		}
 	)
-
-	return artworks
+ 
+	filtered = list(filter(lambda x: x.get('part_of') is None, artworks['items']))
+ 
+ 
+	res: ArtworkResponse = ArtworkResponse(
+		items=filtered,
+		found=artworks['found'],
+		offset=artworks['offset'],
+		rows=artworks['rows'],
+	)
+ 
+	return res


### PR DESCRIPTION
This pull request includes several changes to the `smk_api` service and schema to improve the handling and filtering of artwork search results. The most important changes include the addition of a new constructor in the `ArtworkResponse` class, the inclusion of a filter for artworks on display, and the modification of the query parameters for artwork searches.

### Schema Changes:

* [`app/schemas/smk_api_schemas.py`](diffhunk://#diff-938735cd3bc6f9638056ad5ecf88c20ff7db4cc36e4a733f477ce82f1007cda3L85-R93): Added a new constructor to the `ArtworkResponse` class to initialize additional fields such as `offset`, `rows`, `found`, `items`, `facets`, and `facets_ranges`.

### Service Changes:

* [`app/services/smk_api.py`](diffhunk://#diff-864891baeb528974982d2af96ffb8fedca23d8b43b94a8d4e902ba6db59937b9R32): Added a filter to the `search_artwork` function to only include artworks that are on display.
* [`app/services/smk_api.py`](diffhunk://#diff-864891baeb528974982d2af96ffb8fedca23d8b43b94a8d4e902ba6db59937b9L59-R82): Modified the `query_artwork` function to include a default filter for artworks on display and to change the query fields to `titles`, `creator`, and `tags`. Additionally, the function now filters out artworks that are part of another collection and constructs an `ArtworkResponse` object to return the filtered results.