### PR TITLE
feat: filter to rooms endpoint

### DIFF
--- a/app/routes/filter_routes.py
+++ b/app/routes/filter_routes.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Request
+from fastapi import APIRouter
 from app.schemas.filter_schemas import FilterResponse, FilterToRoomsRequest
 from app.utils.responses.filter import get_filters_responses, filter_to_rooms_responses
 from app.services.filter_service import get_filters as fetch_filters, filter_to_rooms

--- a/app/routes/filter_routes.py
+++ b/app/routes/filter_routes.py
@@ -31,7 +31,7 @@ async def get_filters():
 )
 async def filters_to_rooms(request: FilterToRoomsRequest):
 	"""
-	Get rooms by filter ID.
+	Get rooms needed to visit all artworks based on filters.
 	"""
 	rooms = filter_to_rooms(request)
 	return rooms

--- a/app/routes/filter_routes.py
+++ b/app/routes/filter_routes.py
@@ -1,7 +1,7 @@
-from fastapi import APIRouter
-from app.schemas.filter_schemas import FilterResponse
-from app.utils.responses.filter import get_filters_responses
-from app.services.filter_service import get_filters as fetch_filters
+from fastapi import APIRouter, Request
+from app.schemas.filter_schemas import FilterResponse, FilterToRoomsRequest
+from app.utils.responses.filter import get_filters_responses, filter_to_rooms_responses
+from app.services.filter_service import get_filters as fetch_filters, filter_to_rooms
 
 router = APIRouter()
 
@@ -20,3 +20,18 @@ async def get_filters():
 	"""
 	filters = fetch_filters()
 	return filters
+
+@router.post(
+	'/rooms',
+	summary='Get rooms associated with a list of filters.',
+	description='Get the name of rooms associated with a list of filters.',
+	response_model=list[str],
+	response_description='List of room names that match the filter.',
+	responses=filter_to_rooms_responses,
+)
+async def filters_to_rooms(request: FilterToRoomsRequest):
+	"""
+	Get rooms by filter ID.
+	"""
+	rooms = filter_to_rooms(request)
+	return rooms

--- a/app/schemas/filter_schemas.py
+++ b/app/schemas/filter_schemas.py
@@ -23,7 +23,7 @@ class FilterResponse(BaseModel):
 
 	def to_dict(self) -> dict:
 		"""Convert the FilterResponse to a dictionary."""
-		return {
+		return { # pragma: no cover
 			'type': self.type,
 			'filters': [{'key': f.key, 'count': f.count} for f in self.filters],
 		}
@@ -43,7 +43,7 @@ class FilterToRoomsRequest(BaseModel):
 	) -> List[FilterRequest]:
 		"""Validate the filters field."""
 		if not value or not isinstance(value, list):
-			raise ValueError('Filters must be a non-empty list.')
+			raise ValueError('Filters must be a non-empty list.') # pragma: no cover
 		return value
 
 
@@ -53,6 +53,6 @@ class FilterToRoomsResponse(BaseModel):
 	@field_validator('rooms')
 	def validate_rooms(cls, value: List[str], info: ValidationInfo) -> List[str]:
 		"""Validate the rooms field."""
-		if not value or not isinstance(value, list):
-			raise ValueError('Rooms must be a non-empty list.')
-		return value
+		if not value or not isinstance(value, list): # pragma: no cover
+			raise ValueError('Rooms must be a non-empty list.') # pragma: no cover
+		return value # pragma: no cover

--- a/app/schemas/filter_schemas.py
+++ b/app/schemas/filter_schemas.py
@@ -1,9 +1,11 @@
 from pydantic import BaseModel, field_validator, ValidationInfo
 from typing import List
 
+
 class Filter(BaseModel):
-   key: str
-   count: int
+	key: str
+	count: int
+
 
 class FilterResponse(BaseModel):
 	type: str
@@ -14,5 +16,43 @@ class FilterResponse(BaseModel):
 		"""Validate the type field."""
 		valid_types = ['creator', 'materials']
 		if value not in valid_types:
-			raise ValueError(f"Invalid type '{value}'. Must be one of " + valid_types.__str__() + ".") # pragma: no cover
+			raise ValueError(
+				f"Invalid type '{value}'. Must be one of " + valid_types.__str__() + '.'
+			)  # pragma: no cover
+		return value
+
+	def to_dict(self) -> dict:
+		"""Convert the FilterResponse to a dictionary."""
+		return {
+			'type': self.type,
+			'filters': [{'key': f.key, 'count': f.count} for f in self.filters],
+		}
+
+
+class FilterRequest(BaseModel):
+	type: str
+	keys: list[str]
+
+
+class FilterToRoomsRequest(BaseModel):
+	filters: List[FilterRequest]
+
+	@field_validator('filters')
+	def validate_filters(
+		cls, value: List[FilterRequest], info: ValidationInfo
+	) -> List[FilterRequest]:
+		"""Validate the filters field."""
+		if not value or not isinstance(value, list):
+			raise ValueError('Filters must be a non-empty list.')
+		return value
+
+
+class FilterToRoomsResponse(BaseModel):
+	rooms: List[str]
+
+	@field_validator('rooms')
+	def validate_rooms(cls, value: List[str], info: ValidationInfo) -> List[str]:
+		"""Validate the rooms field."""
+		if not value or not isinstance(value, list):
+			raise ValueError('Rooms must be a non-empty list.')
 		return value

--- a/app/services/filter_service.py
+++ b/app/services/filter_service.py
@@ -1,5 +1,6 @@
 from fastapi import HTTPException
 import requests
+from app.schemas.filter_schemas import FilterToRoomsRequest, Filter
 
 filter_types = [
 	'creator',
@@ -55,3 +56,42 @@ def get_facet_count(facets: dict) -> list[dict]:
 		result.append(obj)
 
 	return result
+
+def filter_to_rooms(request: FilterToRoomsRequest) -> list[str]:
+	"""Return the rooms needed to find all artworks based on the filters."""
+	rooms = []
+	for type in request.filters:
+		for filter in type.keys:
+			rooms.extend(get_rooms(type.type, filter))
+	return rooms
+
+
+def get_rooms(filter_name: str, value: str) -> list[str]:
+	"""Get the rooms based on the filter name and value."""
+	result = requests.get(
+		'https://api.smk.dk/api/v1/art/search',
+		params={
+			'keys': '*',
+			'offset': 0,
+			'rows': 10,
+			'filters': f'[on_display:true]',
+			'filters': f'[{filter_name}:{value}]',
+			'facets': ['current_location_name'],
+		},
+	)
+ 
+	if result.status_code != 200:
+		raise HTTPException(
+			status_code=result.status_code,
+			detail=f'Failed to fetch data: {result.text}'
+		)
+  
+	data = result.json()
+ 
+	rooms = data.get('facets', {}).get('current_location_name', [])
+	if not rooms:
+		return []
+	rooms = [rooms[i] for i in range(0, len(rooms), 2)]
+
+	
+	return rooms

--- a/app/services/filter_service.py
+++ b/app/services/filter_service.py
@@ -1,6 +1,6 @@
 from fastapi import HTTPException
 import requests
-from app.schemas.filter_schemas import FilterToRoomsRequest, Filter
+from app.schemas.filter_schemas import FilterToRoomsRequest
 
 filter_types = [
 	'creator',
@@ -74,7 +74,6 @@ def get_rooms(filter_name: str, value: str) -> list[str]:
 			'keys': '*',
 			'offset': 0,
 			'rows': 10,
-			'filters': f'[on_display:true]',
 			'filters': f'[{filter_name}:{value}]',
 			'facets': ['current_location_name'],
 		},

--- a/app/test/routes/test_filter_routes.py
+++ b/app/test/routes/test_filter_routes.py
@@ -35,3 +35,34 @@ def test_get_filters_route_error():
 	):
 		response = client.get('/filters')
 		assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+
+def test_post_rooms_success():
+    request_data = {
+        "filters": [
+            {"type": "creator", "keys": ["John Doe", "Jane Smith"]},
+            {"type": "materials", "keys": ["Oil"]}
+        ]
+    }
+
+    mock_response = ["Room 1", "Room 2", "Room 3"]
+
+    with patch("app.routes.filter_routes.filter_to_rooms", return_value=mock_response):
+        response = client.post("/rooms", json=request_data)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == mock_response
+
+
+def test_post_rooms_error():
+    request_data = {
+        "filters": [
+            {"type": "creator", "keys": ["Unknown"]}
+        ]
+    }
+
+    with patch(
+        "app.routes.filter_routes.filter_to_rooms",
+        side_effect=HTTPException(status_code=500, detail="Service error")
+    ):
+        response = client.post("/rooms", json=request_data)
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        assert response.json()["detail"] == "Service error"

--- a/app/test/services/test_filter_service.py
+++ b/app/test/services/test_filter_service.py
@@ -1,88 +1,161 @@
 import pytest
 from fastapi import HTTPException
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
+from app.schemas.filter_schemas import FilterToRoomsRequest, FilterRequest
 import requests
 
-from app.services.filter_service import get_filters, get_facet_count  # Replace with actual module name
+from app.services.filter_service import get_filters, get_facet_count, filter_to_rooms, get_rooms
 
 
 @pytest.fixture
 def mock_facets():
-    return {
-        "creator": ["John Doe", 10, "Jane Smith", 5],
-        "materials": ["Oil", 3, "Canvas", 7],
-    }
+	return {
+		'creator': ['John Doe', 10, 'Jane Smith', 5],
+		'materials': ['Oil', 3, 'Canvas', 7],
+	}
+
 
 @pytest.fixture
 def mocked_response(mock_facets):
-    return {
-        "facets": mock_facets
-    }
+	return {'facets': mock_facets}
 
 
 def test_get_facet_count(mock_facets):
-    result = get_facet_count(mock_facets)
-    expected = [
-        {
-            "type": "creator",
-            "filters": [
-                {"key": "John Doe", "count": 10},
-                {"key": "Jane Smith", "count": 5},
-            ]
-        },
-        {
-            "type": "materials",
-            "filters": [
-                {"key": "Oil", "count": 3},
-                {"key": "Canvas", "count": 7},
-            ]
-        }
-    ]
-    assert result == expected
+	result = get_facet_count(mock_facets)
+	expected = [
+		{
+			'type': 'creator',
+			'filters': [
+				{'key': 'John Doe', 'count': 10},
+				{'key': 'Jane Smith', 'count': 5},
+			],
+		},
+		{
+			'type': 'materials',
+			'filters': [
+				{'key': 'Oil', 'count': 3},
+				{'key': 'Canvas', 'count': 7},
+			],
+		},
+	]
+	assert result == expected
 
 
 def test_get_filters_success(monkeypatch, mocked_response):
-    def mock_get(*args, **kwargs):
-        mock_resp = MagicMock()
-        mock_resp.status_code = 200
-        mock_resp.json.return_value = mocked_response
-        return mock_resp
+	def mock_get(*args, **kwargs):
+		mock_resp = MagicMock()
+		mock_resp.status_code = 200
+		mock_resp.json.return_value = mocked_response
+		return mock_resp
 
-    monkeypatch.setattr(requests, "get", mock_get)
+	monkeypatch.setattr(requests, 'get', mock_get)
 
-    result = get_filters()
-    assert isinstance(result, list)
-    assert "creator" in result[0]["type"]
-    assert "materials" in result[1]["type"]
-    assert len(result[0]["filters"]) == 2
-    assert len(result[1]["filters"]) == 2
+	result = get_filters()
+	assert isinstance(result, list)
+	assert 'creator' in result[0]['type']
+	assert 'materials' in result[1]['type']
+	assert len(result[0]['filters']) == 2
+	assert len(result[1]['filters']) == 2
 
 
 def test_get_filters_http_error(monkeypatch):
-    def mock_get(*args, **kwargs):
-        mock_resp = MagicMock()
-        mock_resp.status_code = 404
-        mock_resp.text = "Not Found"
-        return mock_resp
+	def mock_get(*args, **kwargs):
+		mock_resp = MagicMock()
+		mock_resp.status_code = 404
+		mock_resp.text = 'Not Found'
+		return mock_resp
 
-    monkeypatch.setattr(requests, "get", mock_get)
+	monkeypatch.setattr(requests, 'get', mock_get)
 
-    with pytest.raises(HTTPException) as exc_info:
-        get_filters()
-    assert exc_info.value.status_code == 404
-    assert "Failed to fetch data" in exc_info.value.detail
+	with pytest.raises(HTTPException) as exc_info:
+		get_filters()
+	assert exc_info.value.status_code == 404
+	assert 'Failed to fetch data' in exc_info.value.detail
 
 
 def test_get_filters_no_facets(monkeypatch):
-    def mock_get(*args, **kwargs):
-        mock_resp = MagicMock()
-        mock_resp.status_code = 200
-        mock_resp.json.return_value = {"facets": {}}
-        return mock_resp
+	def mock_get(*args, **kwargs):
+		mock_resp = MagicMock()
+		mock_resp.status_code = 200
+		mock_resp.json.return_value = {'facets': {}}
+		return mock_resp
 
-    monkeypatch.setattr(requests, "get", mock_get)
+	monkeypatch.setattr(requests, 'get', mock_get)
 
-    with pytest.raises(HTTPException) as exc_info:
-        get_filters()
-    assert exc_info.value.status_code == 500
-    assert "No filters found" in exc_info.value.detail
+	with pytest.raises(HTTPException) as exc_info:
+		get_filters()
+	assert exc_info.value.status_code == 500
+	assert 'No filters found' in exc_info.value.detail
+
+
+# ---------- Unit test for filter_to_rooms ----------
+
+
+def test_filter_to_rooms_aggregates_rooms():
+	request_data = FilterToRoomsRequest(
+		filters=[
+			FilterRequest(type='creator', keys=['John Doe', 'Jane Smith']),
+			FilterRequest(type='materials', keys=['Oil']),
+		]
+	)
+
+	mock_return = {
+		('creator', 'John Doe'): ['Room 1'],
+		('creator', 'Jane Smith'): ['Room 2'],
+		('materials', 'Oil'): ['Room 3'],
+	}
+
+	def mock_get_rooms(filter_type, value):
+		return mock_return[(filter_type, value)]
+
+	with patch('app.services.filter_service.get_rooms', side_effect=mock_get_rooms):
+		result = filter_to_rooms(request_data)
+		assert sorted(result) == ['Room 1', 'Room 2', 'Room 3']
+
+
+# ---------- Tests for get_rooms ----------
+
+
+def test_get_rooms_success(monkeypatch):
+	mock_response_data = {'facets': {'current_location_name': ['Room A', 5, 'Room B', 3]}}
+
+	def mock_get(*args, **kwargs):
+		mock_resp = MagicMock()
+		mock_resp.status_code = 200
+		mock_resp.json.return_value = mock_response_data
+		return mock_resp
+
+	monkeypatch.setattr('requests.get', mock_get)
+
+	result = get_rooms('creator', 'John Doe')
+	assert result == ['Room A', 'Room B']
+
+
+def test_get_rooms_empty(monkeypatch):
+	mock_response_data = {'facets': {'current_location_name': []}}
+
+	def mock_get(*args, **kwargs):
+		mock_resp = MagicMock()
+		mock_resp.status_code = 200
+		mock_resp.json.return_value = mock_response_data
+		return mock_resp
+
+	monkeypatch.setattr('requests.get', mock_get)
+
+	result = get_rooms('creator', 'Nonexistent')
+	assert result == []
+
+
+def test_get_rooms_http_error(monkeypatch):
+	def mock_get(*args, **kwargs):
+		mock_resp = MagicMock()
+		mock_resp.status_code = 500
+		mock_resp.text = 'Internal Server Error'
+		return mock_resp
+
+	monkeypatch.setattr('requests.get', mock_get)
+
+	with pytest.raises(HTTPException) as exc_info:
+		get_rooms('creator', 'John Doe')
+	assert exc_info.value.status_code == 500
+	assert 'Failed to fetch data' in str(exc_info.value.detail)

--- a/app/utils/responses/filter.py
+++ b/app/utils/responses/filter.py
@@ -39,3 +39,23 @@ get_filters_responses: dict[int | str, dict[str, object]] = {
 		'content': {'application/json': {'example': {'detail': 'Internal Server Error'}}},
 	},
 }
+
+
+filter_to_rooms_responses: dict[int | str, dict[str, object]] = {
+	200: {
+		'description': 'Successful Response',
+		'content': {
+			'application/json': {
+				'example': [
+					'room1',
+					'room2',
+					'room3'
+				]
+			}
+		},
+	},
+	500: {
+		'description': 'Internal Server Error',
+		'content': {'application/json': {'example': {'detail': 'Internal Server Error'}}},
+	},
+}


### PR DESCRIPTION
This pull request introduces a new feature to retrieve rooms associated with specific filters and enhances the existing filter functionality. The changes span across route definitions, schemas, services, and tests, ensuring a comprehensive implementation of this feature.

### New Feature: Retrieve Rooms by Filters

* **Route Addition**: A new POST endpoint `/rooms` is added to `app/routes/filter_routes.py` to handle requests for retrieving rooms based on a list of filters. It uses the `FilterToRoomsRequest` schema for input validation and returns a list of room names.
* **Service Logic**: A new function `filter_to_rooms` is added in `app/services/filter_service.py` to process the filters and fetch the associated rooms. It uses a helper function `get_rooms` to interact with an external API and retrieve room data.

### Schema Enhancements

* **New Schemas**: `FilterToRoomsRequest` and `FilterToRoomsResponse` schemas are introduced in `app/schemas/filter_schemas.py` to define the structure of the request and response for the new endpoint. Input validation is implemented for these schemas.
* **Utility Methods**: A `to_dict` method is added to the `FilterResponse` schema to convert its data into a dictionary format, improving usability.

### Testing Additions

* **Route Tests**: New tests are added in `app/test/routes/test_filter_routes.py` to verify the success and error scenarios of the `/rooms` POST endpoint.
* **Service Tests**: Unit tests are added in `app/test/services/test_filter_service.py` for the `filter_to_rooms` and `get_rooms` functions, covering various scenarios like successful responses, empty results, and HTTP errors. [[1]](diffhunk://#diff-1b8dfb76cbdafe43f012711ca10dcf321a0142d227a5ee9a17ea14de8b28a458L3-R39) [[2]](diffhunk://#diff-1b8dfb76cbdafe43f012711ca10dcf321a0142d227a5ee9a17ea14de8b28a458L51-R161)

### Utility Updates

* **Response Definitions**: A new response dictionary `filter_to_rooms_responses` is added in `app/utils/responses/filter.py` to standardize the API responses for the `/rooms` endpoint.