### PR TITLE
Feat: Artwork model include image_thumbnail & frontend_url 

### DIFF
--- a/app/schemas/smk_api_schemas.py
+++ b/app/schemas/smk_api_schemas.py
@@ -73,6 +73,7 @@ class Artwork(BaseModel):
 	titles: Optional[List[Title]] = []
 	colors: Optional[List[str]] = []
 	artist: List[str] = []
+	image_thumbnail: Optional[str] = None
 
 
 class ArtworkResponse(BaseModel):
@@ -109,6 +110,7 @@ artwork_response_example: Dict[int | str, Dict[str, Any]] = {
 				'titles': [],
 				'colors': ['Red', 'Blue'],
 				'artist': ['John Doe'],
+				'image_thumbnail': 'https://example.com/image.jpg',
 			},
 			{
 				'responsible_department': 'Department of Sculptures',
@@ -120,6 +122,7 @@ artwork_response_example: Dict[int | str, Dict[str, Any]] = {
 				'titles': [],
 				'colors': ['White'],
 				'artist': ['Jane Smith'],
+				'image_thumbnail': 'https://example.com/image.jpg',
 			},
 		],
 		'facets': {},

--- a/app/schemas/smk_api_schemas.py
+++ b/app/schemas/smk_api_schemas.py
@@ -74,6 +74,7 @@ class Artwork(BaseModel):
 	colors: Optional[List[str]] = []
 	artist: List[str] = []
 	image_thumbnail: Optional[str] = None
+	frontend_url: Optional[str] = None
 
 
 class ArtworkResponse(BaseModel):
@@ -111,6 +112,7 @@ artwork_response_example: Dict[int | str, Dict[str, Any]] = {
 				'colors': ['Red', 'Blue'],
 				'artist': ['John Doe'],
 				'image_thumbnail': 'https://example.com/image.jpg',
+				'frontend_url': 'https://example.com/artwork/12345',
 			},
 			{
 				'responsible_department': 'Department of Sculptures',
@@ -123,6 +125,7 @@ artwork_response_example: Dict[int | str, Dict[str, Any]] = {
 				'colors': ['White'],
 				'artist': ['Jane Smith'],
 				'image_thumbnail': 'https://example.com/image.jpg',
+				'frontend_url': 'https://example.com/artwork/67890',
 			},
 		],
 		'facets': {},


### PR DESCRIPTION
This pull request introduces two new optional fields, `image_thumbnail` and `frontend_url`, to the `Artwork` model in the `smk_api_schemas.py` file. These changes enhance the schema to include additional metadata for artworks, such as a thumbnail image URL and a frontend URL for the artwork's page.

### Schema updates:

* Added `image_thumbnail` and `frontend_url` as optional fields to the `Artwork` model to support additional metadata. (`app/schemas/smk_api_schemas.py`, [app/schemas/smk_api_schemas.pyR76-R77](diffhunk://#diff-938735cd3bc6f9638056ad5ecf88c20ff7db4cc36e4a733f477ce82f1007cda3R76-R77))

### Test data updates:

* Updated test data in the `__init__` method to include values for the new `image_thumbnail` and `frontend_url` fields, ensuring compatibility with the updated schema. (`app/schemas/smk_api_schemas.py`, [[1]](diffhunk://#diff-938735cd3bc6f9638056ad5ecf88c20ff7db4cc36e4a733f477ce82f1007cda3R114-R115) [[2]](diffhunk://#diff-938735cd3bc6f9638056ad5ecf88c20ff7db4cc36e4a733f477ce82f1007cda3R127-R128)