### PR TITLE
update: added timeout param

### DIFF
--- a/app/services/smk_api.py
+++ b/app/services/smk_api.py
@@ -33,7 +33,7 @@ async def search_artwork(keys: str):
 	}
 
 	try:
-		async with httpx.AsyncClient() as client:
+		async with httpx.AsyncClient(timeout=10.0) as client:
 			response = await client.get('https://api.smk.dk/api/v1/art/search', params=params)
 			response.raise_for_status()
 			data = response.json()


### PR DESCRIPTION
This pull request introduces a minor improvement to the `search_artwork` function in `app/services/smk_api.py`. The change sets a timeout for the HTTP client to ensure requests do not hang indefinitely.

* [`app/services/smk_api.py`](diffhunk://#diff-864891baeb528974982d2af96ffb8fedca23d8b43b94a8d4e902ba6db59937b9L36-R36): Updated the `httpx.AsyncClient` initialization to include a `timeout` parameter set to 10.0 seconds.- changed the asyncclient in httpx to have timeout = 10 to allow for calls from frontend to not timeout